### PR TITLE
Fixed: adding expense without a company

### DIFF
--- a/caffe/cash/forms.py
+++ b/caffe/cash/forms.py
@@ -34,7 +34,6 @@ class ExpenseForm(forms.ModelForm):
         super(ExpenseForm, self).__init__(*args, **kwargs)
         self.fields['name'].label = 'Nazwa'
         self.fields['company'].label = 'Firma'
-        self.fields['company'].empty_label = None
         self.fields['company'].required = False
 
 


### PR DESCRIPTION
Now one can add new Expense without a company (for example newspapers don't need a company).